### PR TITLE
Database issues no longer prevent errors from being sent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes for Sentry Logger
 
+## 1.1.7 - 2021-07-01
+
+### Fixed
+- Database issues no longer prevent errors from being sent.
+
 ## 1.1.6 - 2021-05-30
 
 ### Fixed

--- a/src/log/SentryTarget.php
+++ b/src/log/SentryTarget.php
@@ -182,13 +182,17 @@ class SentryTarget extends \yii\log\Target
                     $scope->setExtra('Request Route', $request->getAbsoluteUrl());
                 }
 
-                $db = Craft::$app->getDb();
-                $dbVersion = App::normalizeVersion($db->getSchema()->getServerVersion());
+                try {
+                    $db = Craft::$app->getDb();
+                    $dbVersion = App::normalizeVersion($db->getSchema()->getServerVersion());
 
-                if ($db->getIsMysql()) {
-                    $scope->setExtra('MySQL Version', $dbVersion);
-                } else {
-                    $scope->setExtra('PostgreSQL Version', $dbVersion);
+                    if ($db->getIsMysql()) {
+                        $scope->setExtra('MySQL Version', $dbVersion);
+                    } else {
+                        $scope->setExtra('PostgreSQL Version', $dbVersion);
+                    }
+                } catch (\Throwable $e) {
+                    // Database is unavailable. Continue and send original error...
                 }
 
                 if ($message instanceof \Throwable) {


### PR DESCRIPTION
When there is a problem with the database, an additional exception will be thrown during the `export` method, preventing the original exception from being sent:

```
2021-06-30 14:45:11 [-][-][-][warning][yii\log\Dispatcher::dispatch] Unable to send log via diginov\sentry\log\SentryTarget: Exception (Database Connection Error) 'craft\errors\DbConnectException' with message 'Craft CMS can’t connect to the database with the credentials in config/db.php.' 
```

This change allows for database problems, continuing when there is a problem and sending the original event.