### PR TITLE
Add support for $except

### DIFF
--- a/src/models/SettingsModel.php
+++ b/src/models/SettingsModel.php
@@ -60,6 +60,11 @@ class SettingsModel extends \craft\base\Model
     /**
      * @var array
      */
+    public array $except = [];
+
+    /**
+     * @var array
+     */
     public array $userPrivacy = ['id', 'email', 'username', 'ip_address', 'cookies', 'permissions'];
 
     // Public Methods


### PR DESCRIPTION
`$except` is supported in yii's `Target`, but is silently dropped in `SettingsModel`.